### PR TITLE
fixes docker build and release ci pipeline

### DIFF
--- a/.github/scripts/docker-build.sh
+++ b/.github/scripts/docker-build.sh
@@ -3,6 +3,6 @@
 DOCKERFILE_PATH="$1"
 REPO="$2"
 GITHUB_SHA="$3"
-docker build $DOCKERFILE_PATH -t $REPO:${GITHUB_SHA} -t $REPO:rolling --cache-from $REPO:rolling --cache-from $REPO:latest
+docker build $DOCKERFILE_PATH -t $REPO:${GITHUB_SHA} -t $REPO:rolling
 docker push $REPO:${GITHUB_SHA}
 docker push $REPO:rolling

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,13 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: docker login docker.pkg.github.com -u $GITHUB_ACTOR -p ${{secrets.GITHUB_TOKEN}}
-      - run: .github/scripts/docker-build.sh $REPO ${GITHUB_SHA}
+      - if: ${{ !env.ACT }}
+        run: docker login docker.pkg.github.com -u $GITHUB_ACTOR -p ${{secrets.GITHUB_TOKEN}}
+      - run: .github/scripts/docker-build.sh . $REPO ${GITHUB_SHA}
 
   release:
     runs-on: ubuntu-latest
     needs: build
     steps:
       - uses: actions/checkout@v2
-      - run: docker login docker.pkg.github.com -u $GITHUB_ACTOR -p ${{secrets.GITHUB_TOKEN}}
-      - run: .github/scripts/docker-release.sh $REPO/${GITHUB_SHA} $REPO/latest
+      - if: ${{ !env.ACT }}
+        run: docker login docker.pkg.github.com -u $GITHUB_ACTOR -p ${{secrets.GITHUB_TOKEN}}
+      - run: .github/scripts/docker-release.sh $REPO:${GITHUB_SHA} $REPO:latest


### PR DESCRIPTION
The current CI Pipeline (Github actions) are failing and don't push the new docker images to the registry. 
This pull fixes this issue.