### PR TITLE
switches ci to new github docker repo

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,7 +5,7 @@ on:
       - 'master'
 env:
   # This is a base repository and we use ${GITHUB_REF##*/} to set the version of the container
-  REPO: docker.pkg.github.com/aragon/v2-datafeed
+  REPO: ghcr.io/aragon/v2-datafeed
 
 jobs:
   build:
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - if: ${{ !env.ACT }}
-        run: docker login docker.pkg.github.com -u $GITHUB_ACTOR -p ${{secrets.GITHUB_TOKEN}}
+        run: docker login ghcr.io -u $GITHUB_ACTOR -p ${{secrets.GITHUB_TOKEN}}
       - run: .github/scripts/docker-build.sh . $REPO ${GITHUB_SHA}
 
   release:
@@ -22,5 +22,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - if: ${{ !env.ACT }}
-        run: docker login docker.pkg.github.com -u $GITHUB_ACTOR -p ${{secrets.GITHUB_TOKEN}}
+        run: docker login ghcr.io -u $GITHUB_ACTOR -p ${{secrets.GITHUB_TOKEN}}
       - run: .github/scripts/docker-release.sh $REPO:${GITHUB_SHA} $REPO:latest


### PR DESCRIPTION
The github docker registry has been replaced by the container registry (https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-docker-registry).
This should fix the remaining issue with pushing the new docker image.